### PR TITLE
Add x-axis label and use helper function for size instead of hard-coding

### DIFF
--- a/split-bar-chart/chart.css
+++ b/split-bar-chart/chart.css
@@ -31,6 +31,7 @@ div.rowLabel span{
     display:block;
     padding-right:10px;
     height:30px;
+    line-height: 1;
 }
 
 div.column span{

--- a/split-bar-chart/config.js
+++ b/split-bar-chart/config.js
@@ -11,20 +11,22 @@ config = {
 			"#F66068"
 		],
 		// colours is an array for the colours of the bars
-		// e.g. if mono use ["206095"]
+		// e.g. if mono use ["#206095"]
 		// e.g if divergent you can use ["#206095","#F66068"]
 		// e.g if categorical ["#206095", "#27A0CC","#871A5B", "#A8BD3A","#F66068"]
 		"numberFormat": ".0f",
 		"rowWidth": {
 			"sm": 100,
-			"not sm": 140
+			"md": 140,
+			"lg": 140,
 		},
 		// rowWidth set the width of y category column in pixel
-		"accessibleSummary":
-			"This chart has been hidden from screen readers. The main message of the chart is summarised in the chart title.",
+		"accessibleSummary": "This chart has been hidden from screen readers. The main message of the chart is summarised in the chart title.",
 		"sourceText": "Office for National Statistics",
+		"xAxisLabel": "x axis label",
 		"threshold_sm": 510
 	},
+	"optional": {},
 	//Don't adjust this part - it only affects the chart build tool
 	"chart_build": {
 		"graphic_data_url": "text",

--- a/split-bar-chart/script.js
+++ b/split-bar-chart/script.js
@@ -1,3 +1,5 @@
+import { initialise} from "../lib/helpers.js";
+
 let graphic = d3.select('#graphic');
 let legend = d3.select('#legend');
 let pymChild = null;
@@ -8,11 +10,7 @@ function drawGraphic() {
 	graphic.selectAll('*').remove();
 	legend.selectAll('*').remove();
 
-	if (parseInt(graphic.style('width')) < config.essential.threshold_sm) {
-		size = 'sm';
-	} else {
-		size = 'not sm';
-	}
+	size = initialise(size);
 
 	//population accessible summmary
 	d3.select('#accessibleSummary').html(config.essential.accessibleSummary);
@@ -216,6 +214,18 @@ function drawGraphic() {
 		.style('position', 'relative')
 		.style('left', 'calc(' + x(0) + '%' + ' - 5px)')
 		.html(0);
+
+	// x-axis label
+	finalrow
+		.append('div')
+		.attr('class', 'axis--label') 
+		.style('width', '100%')
+		.style('text-align', 'right') 
+		.style('margin-top', '10px') 
+		.style('padding-right', '10px') 
+		.append('span')
+		.style('white-space', 'nowrap') 
+		.text(config.essential.xAxisLabel);
 
 	//create link to source
 	d3.select('#source').text('Source: ' + config.essential.sourceText);


### PR DESCRIPTION
Fixes for split bar chart:

* Use `initialise()` function for size instead of hard-coding
* Add x-axis labels

Closes #222 