### PR TITLE
Add template for range CI area plot

### DIFF
--- a/range-ci-area-grouped/chart.css
+++ b/range-ci-area-grouped/chart.css
@@ -1,0 +1,27 @@
+line.between{
+  stroke:#c6c6c6;
+  stroke-width:3px;
+}
+
+.dataLabels{
+  font-weight: 600;
+  font-size: 14px;
+}
+
+div.legend--icon--diamond{
+  height: 12px;
+  width: 12px;
+  align-self: center;
+  flex-shrink: 0;
+  forced-color-adjust: none;
+  transform: rotate(45deg);
+}
+
+.legend--icon--circle {
+  height: 12px;
+  width: 12px;
+  border-radius: 50%;
+  align-self: flex-start;
+  flex-shrink: 0;
+  vertical-align: top !important;
+}

--- a/range-ci-area-grouped/config.js
+++ b/range-ci-area-grouped/config.js
@@ -3,8 +3,8 @@ config = {
 		"graphic_data_url": "data.csv",
 		"colour_palette": [
 			"#206095",
-			"#27A0CC",
 			"#871A5B",
+			"#27A0CC",
 			"#A8BD3A",
 			"#F66068",
 			"#118C7B"

--- a/range-ci-area-grouped/config.js
+++ b/range-ci-area-grouped/config.js
@@ -1,0 +1,57 @@
+config = {
+	"essential": {
+		"graphic_data_url": "data.csv",
+		"colour_palette": [
+			"#206095",
+			"#27A0CC",
+			"#871A5B",
+			"#A8BD3A",
+			"#F66068",
+			"#118C7B"
+		],
+		"sourceText": "Office for National Statistics",
+		"accessibleSummary":
+			"A range plot with confidence intervals. This chart is hidden from screen readers. The main message is summarised by the chart title and the data behind the chart is available to download below.",
+		"xAxisTickFormat": ".0f",
+		"xAxisLabel": "x axis label",
+		"xDomain": [0, 160],
+		// either auto or a custom domain as an array e.g [0,100]
+		"CI_legend": true,
+		"CI_legend_interval_text": "Likely range (95% confidence interval)",
+		"CI_legend_text": "Estimated value"
+	},
+	"optional": {
+		"margin": {
+			"sm": {
+				"top": 5,
+				"right": 20,
+				"bottom": 40,
+				"left": 100
+			},
+			"md": {
+				"top": 5,
+				"right": 20,
+				"bottom": 40,
+				"left": 100
+			},
+			"lg": {
+				"top": 5,
+				"right": 20,
+				"bottom": 40,
+				"left": 120
+			}
+		},
+		"seriesHeight": {
+			"sm": 20,
+			"md": 20,
+			"lg": 20
+		},
+		"xAxisTicks": {
+			"sm": 4,
+			"md": 8,
+			"lg": 10
+		},
+		"mobileBreakpoint": 510,
+		"mediumBreakpoint": 600
+	}
+};

--- a/range-ci-area-grouped/data.csv
+++ b/range-ci-area-grouped/data.csv
@@ -1,0 +1,27 @@
+name,group,series,value,min,max
+England,Group name 1,series 1,55.15726549,44.79967469,65.51485629
+Wales,Group name 1,series 1,53,20,86
+North East,Group name 2,series 1,38.29309225,21.04544788,55.54073662
+North West,Group name 2,series 1,45.1373065,39.13579896,51.13881403
+Yorkshire and The Humber,Group name 2,series 1,60,40,80
+East Midlands,Group name 2,series 1,40.56442504,29.36591976,51.76293031
+West Midlands,Group name 2,series 1,60.02733084,39.86949419,80.18516748
+East,Group name 2,series 1,50.79985161,17.64884078,83.95086243
+London,Group name 2,series 1,50.89339154,43.91069538,57.87608769
+South West,Group name 2,series 1,29.68960375,9.379207492,50
+South East,Group name 2,series 1,35.07397305,8.973142806,61.1748033
+Another name,Group name 3,series 1,45.19066503,24.79415817,65.58717189
+And another,Group name 3,series 1,43,33,53
+England,Group name 1,series 2,110.1572655,99.79967469,120.5148563
+Wales,Group name 1,series 2,120,90,150
+North East,Group name 2,series 2,93.29309224,76.04544788,110.5407366
+North West,Group name 2,series 2,100.1373065,94.13579896,106.138814
+Yorkshire and The Humber,Group name 2,series 2,118.1506859,85.57469086,150.726681
+East Midlands,Group name 2,series 2,95.56442503,84.36591976,106.7629303
+West Midlands,Group name 2,series 2,115.0273308,94.86949419,135.1851675
+East,Group name 2,series 2,124.4754312,110,138.9508624
+London,Group name 2,series 2,105.8933915,98.91069538,112.8760877
+South West,Group name 2,series 2,92.14356115,64.37920749,119.9079148
+South East,Group name 2,series 2,90.07397306,63.97314281,116.1748033
+Another name,Group name 3,series 2,100.190665,79.79415817,120.5871719
+And another,Group name 3,series 2,97,93,101

--- a/range-ci-area-grouped/index.html
+++ b/range-ci-area-grouped/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- TEMPLATE https://github.com/ONSvisual/census-charts/tree/main/range-plot -->
+
+<head>
+  <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
+  <title>Range area plot</title>
+
+  <meta name="template" content="range-plot">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8" />
+  <meta name="robots" content="noindex" />
+  <meta name="googlebot" content="indexifembedded" />
+
+  <link rel="stylesheet" href="../lib/globalStyle.css" />
+  <link rel="stylesheet" href="./chart.css"/>
+</head>
+
+<body>
+
+  <h5 id="accessibleSummary" class="visuallyhidden"></h5>
+
+  <div aria-hidden="true" id="legend"></div>
+
+  <div id="graphic" aria-hidden="true">
+    <!-- <img src="fallback.png" alt="[Chart]" /> -->
+  </div>
+
+
+  <h5 id="source">
+  </h5>
+
+  <script src="https://cdn.ons.gov.uk/vendor/d3/6.3.0/d3.min.js" type="text/javascript"></script>
+  <script src="https://cdn.ons.gov.uk/vendor/pym/1.3.2/pym.js" type="text/javascript"></script>
+  <script src="./config.js"></script>
+  <script src="./script.js" type="module"></script>
+
+</body>
+
+</html>

--- a/range-ci-area-grouped/script.js
+++ b/range-ci-area-grouped/script.js
@@ -1,0 +1,253 @@
+import { initialise, wrap, addSvg, addAxisLabel, addDirectionArrow, addElbowArrow } from "../lib/helpers.js";
+
+let graphic = d3.select('#graphic');
+let legend = d3.select('#legend');
+let pymChild = null;
+let graphic_data, size, groups, xDomain, divs, svgs, charts;
+
+function drawGraphic() {
+
+	//Set up some of the basics and return the size value ('sm', 'md' or 'lg')
+	size = initialise(size);
+
+	let margin = config.optional.margin[size];
+	let chart_width =
+		parseInt(graphic.style('width')) - margin.left - margin.right;
+
+	groups = d3.groups(graphic_data, (d) => d.group);
+
+	if (config.essential.xDomain == 'auto') {
+		let min = 1000000;
+		let max = 0;
+		for (i = 2; i < graphic_data.columns.length; i++) {
+			min = d3.min([
+				min,
+				d3.min(graphic_data, (d) => +d[graphic_data.columns[i]])
+			]);
+			max = d3.max([
+				max,
+				d3.max(graphic_data, (d) => +d[graphic_data.columns[i]])
+			]);
+		}
+		xDomain = [min, max];
+	} else {
+		xDomain = config.essential.xDomain;
+	}
+
+	//set up scales
+	const x = d3.scaleLinear().range([0, chart_width]).domain(xDomain);
+
+	const series = [...new Set(graphic_data.map(d => d.series))]
+	const colour = d3
+		.scaleOrdinal()
+		.range(config.essential.colour_palette)
+		.domain(series);
+
+	// create the y scale in groups
+	groups.map(function (d) {
+		//height
+		d[2] = config.optional.seriesHeight[size] * d[1].length;
+
+		// y scale
+		d[3] = d3
+			.scalePoint()
+			.padding(0.5)
+			.range([0, d[2]])
+			.domain(d[1].map((d) => d.name));
+		//y axis generator
+		d[4] = d3.axisLeft(d[3]).tickSize(0).tickPadding(10);
+	});
+
+	//set up xAxis generator
+	let xAxis = d3.axisBottom(x)
+		.ticks(config.optional.xAxisTicks[size])
+		.tickFormat(d3.format(config.essential.xAxisTickFormat));
+
+	divs = graphic.selectAll('div.categoryLabels').data(groups).join('div');
+
+	if (groups.length > 1) { divs.append('p').attr('class', 'groupLabels').html((d) => d[0]) }
+
+	charts = addSvg({
+		svgParent: divs,
+		chart_width: chart_width,
+		height: (d) => d[2] + margin.top + margin.bottom,
+		margin: margin
+	})
+
+	charts.each(function (d) {
+		d3.select(this)
+			.append('g')
+			.attr('class', 'y axis')
+			.call(d[4])
+			.selectAll('text')
+			.call(wrap, margin.left - 10);
+
+		d3.select(this)
+			.append('g')
+			.attr('transform', (d) => 'translate(0,' + d[2] + ')')
+			.attr('class', 'x axis')
+			.each(function () {
+				d3.select(this)
+					.call(xAxis.tickSize(-d[2]))
+					.selectAll('line')
+					.each(function (e) {
+						if (e == 0) {
+							d3.select(this).attr('class', 'zero-line');
+						}
+					});
+			});
+	});
+
+	const rectHeight = 15
+
+	charts
+		.selectAll("rect")
+		.data((d) => d[1])
+		.join("rect")
+		.attr("x", d => x(Number(d.min)))
+		.attr("y", (d, i) => groups.filter((e) => e[0] == d.group)[0][3](d.name) - rectHeight / 2)
+		.attr("width", d => Math.abs(x(Number(d.max)) - x(Number(d.min))))
+		.attr("height", rectHeight)
+		.attr("fill", d => colour(d.series))
+		.attr("opacity", 0.8);
+
+	charts
+		.selectAll("path.diamond")
+		.data((d) => d[1])
+		.join("path")
+		.attr("class", "diamond")
+		.attr("d", d3.symbol().type(d3.symbolDiamond).size(45))
+		.attr("transform", d => `translate(${x(d.value)} ${groups.filter((f) => f[0] == d.group)[0][3](d.name) - 0}) scale(1.5, 1)`)
+		.attr("fill", "white")
+		.attr("stroke", "black");
+
+	// This does the x-axis label
+	charts.each(function (d, i) {
+		if (i == groups.length - 1) {
+			addAxisLabel({
+				svgContainer: d3.select(this),
+				xPosition: chart_width,
+				yPosition: d[2] + 35,
+				text: config.essential.xAxisLabel,
+				textAnchor: "end",
+				wrapWidth: chart_width
+			});
+		}
+	});
+
+	// Set up the legend
+	let legend = d3
+			.select('#legend')
+
+	let legenditem = legend
+		.selectAll('div.legend--item')
+		.data(
+			d3.zip(
+				series,
+				config.essential.colour_palette
+			)
+		)
+		.enter()
+		.append('div')
+		.attr('class', 'legend--item');
+
+	legenditem
+		.append('div')
+		.attr('class', (d, i) => config.essential.useDiamonds && i == 0 ? 'legend--icon--diamond' : 'legend--icon--circle')
+		.style('background-color', function (d) {
+			return d[1];
+		});
+
+	legenditem
+		.append('div')
+		.append('p')
+		.attr('class', 'legend--text')
+		.html(function (d) {
+			return d[0];
+		});
+
+	if (config.essential.CI_legend) {
+		
+
+		const ciSvg = legend
+			.append('div')
+			.attr('class', 'legend--item')
+			.append('svg')
+			.attr('width', 300)
+			.attr('height', 60);
+
+		ciSvg.append('rect')
+			.attr('x', 0)
+			.attr('y', 0)
+			.attr('width', 50)
+			.attr('height', 15)
+			.attr('fill', "#959495")
+			.attr('fill-opacity', 0.3);
+
+
+		ciSvg.append("path")
+			.attr("d", d3.symbol().type(d3.symbolDiamond).size(45))
+			.attr("transform", "translate(25, 7.5) scale(1.5, 1)")
+			.attr("fill", "white")
+			.attr("stroke", "#959495");
+
+
+		addElbowArrow(
+			ciSvg,                // svgName
+			25,                   // startX
+			25,                   // startY
+			68,                   // endX
+			47,                    // endY
+			"vertical-first",     // bendDirection
+			"start",                // arrowAnchor
+			config.essential.CI_legend_text, // thisText
+			150,                  // wrapWidth
+			10,                   // textAdjustY
+			"top",               // wrapVerticalAlign
+			"#414042",            // arrowColour
+			"end"              // textAlignment
+		)
+
+		addDirectionArrow(
+			//name of your svg, normally just SVG
+			ciSvg,
+			//direction of arrow: left, right, up or down
+			'left',
+			//anchor end or start (end points the arrow towards your x value, start points away)
+			'end',
+			//x value
+			50,
+			//y value
+			3,
+			//alignment - left or right for vertical arrows, above or below for horizontal arrows
+			'right',
+			//annotation text
+			config.essential.CI_legend_interval_text,
+			//wrap width
+			150,
+			//text adjust y
+			0,
+			//Text vertical align: top, middle or bottom (default is middle)
+			'bottom'
+		)
+	}
+
+
+	//create link to source
+	d3.select('#source').text('Source: ' + config.essential.sourceText);
+
+	//use pym to calculate chart dimensions
+	if (pymChild) {
+		pymChild.sendHeight();
+	}
+}
+
+d3.csv(config.essential.graphic_data_url).then((data) => {
+	//load chart data
+	graphic_data = data;
+
+	//use pym to create iframed chart dependent on specified variables
+	pymChild = new pym.Child({
+		renderCallback: drawGraphic
+	});
+});

--- a/range-ci-area-grouped/script.js
+++ b/range-ci-area-grouped/script.js
@@ -98,7 +98,7 @@ function drawGraphic() {
 			});
 	});
 
-	const rectHeight = 15
+	const rectHeight = 16
 
 	charts
 		.selectAll("rect")
@@ -109,17 +109,20 @@ function drawGraphic() {
 		.attr("width", d => Math.abs(x(Number(d.max)) - x(Number(d.min))))
 		.attr("height", rectHeight)
 		.attr("fill", d => colour(d.series))
-		.attr("opacity", 0.8);
+		.attr("opacity", 0.65);
 
 	charts
-		.selectAll("path.diamond")
+		.selectAll('rect.value')
 		.data((d) => d[1])
-		.join("path")
-		.attr("class", "diamond")
-		.attr("d", d3.symbol().type(d3.symbolDiamond).size(45))
-		.attr("transform", d => `translate(${x(d.value)} ${groups.filter((f) => f[0] == d.group)[0][3](d.name) - 0}) scale(1.5, 1)`)
+		.join('rect')
+		.attr('x', (d) => x(d.value) - 5)
+		.attr('y', (d) => groups.filter((f) => f[0] == d.group)[0][3](d.name) - 5)
+		.attr('width', 10)
+		.attr('height', 10)
+		.attr('transform', (d) => `rotate(45 ${x(d.value) + 0} ${groups.filter((f) => f[0] == d.group)[0][3](d.name) - 0})`)
 		.attr("fill", "white")
-		.attr("stroke", "black");
+		.attr("stroke-width", "2px")
+		.attr('stroke', d => colour(d.series));
 
 	// This does the x-axis label
 	charts.each(function (d, i) {
@@ -137,7 +140,7 @@ function drawGraphic() {
 
 	// Set up the legend
 	let legend = d3
-			.select('#legend')
+		.select('#legend')
 
 	let legenditem = legend
 		.selectAll('div.legend--item')
@@ -167,7 +170,7 @@ function drawGraphic() {
 		});
 
 	if (config.essential.CI_legend) {
-		
+
 
 		const ciSvg = legend
 			.append('div')
@@ -178,18 +181,22 @@ function drawGraphic() {
 
 		ciSvg.append('rect')
 			.attr('x', 0)
-			.attr('y', 0)
+			.attr('y', 1)
 			.attr('width', 50)
-			.attr('height', 15)
+			.attr('height', 16)
 			.attr('fill', "#959495")
-			.attr('fill-opacity', 0.3);
+			.attr('fill-opacity', 0.65);
 
-
-		ciSvg.append("path")
-			.attr("d", d3.symbol().type(d3.symbolDiamond).size(45))
-			.attr("transform", "translate(25, 7.5) scale(1.5, 1)")
+		ciSvg
+			.append("rect")
+			.attr('x', 25)
+			.attr('y', 2)
+			.attr('width', 10)
+			.attr('height', 10)
+			.attr('transform', `rotate(45 ${25} ${2})`)
 			.attr("fill", "white")
-			.attr("stroke", "#959495");
+			.attr("stroke-width", "2px")
+			.attr('stroke', "#959495");
 
 
 		addElbowArrow(

--- a/range-ci-area-grouped/script.js
+++ b/range-ci-area-grouped/script.js
@@ -122,7 +122,10 @@ function drawGraphic() {
 		.attr('transform', (d) => `rotate(45 ${x(d.value) + 0} ${groups.filter((f) => f[0] == d.group)[0][3](d.name) - 0})`)
 		.attr("fill", "white")
 		.attr("stroke-width", "2px")
-		.attr('stroke', d => colour(d.series));
+		.attr('stroke', d => colour(d.series))
+		.attr('rx',1)
+		.attr('ry',1);
+
 
 	// This does the x-axis label
 	charts.each(function (d, i) {
@@ -196,7 +199,9 @@ function drawGraphic() {
 			.attr('transform', `rotate(45 ${25} ${2})`)
 			.attr("fill", "white")
 			.attr("stroke-width", "2px")
-			.attr('stroke', "#959495");
+			.attr('stroke', "#959495")
+			.attr('rx',1)
+			.attr('ry',1);
 
 
 		addElbowArrow(


### PR DESCRIPTION
* Adds a template for CIs that don't overlap and should be shown on the same line as per [this chart](https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandlifeexpectancies/bulletins/adultsmokinghabitsingreatbritain/2023)
* Based on the range plot template, and follows the same styling 
* Ignore the branch name (doesn't add a clustered version)!

Partially addresses #286 and #131

Example: 
![image](https://github.com/user-attachments/assets/a683fc00-5f9d-4026-bc24-f105d9381cba)
