### PR TITLE
PopPyramid use integer height comment

### DIFF
--- a/population-pyramid-static-with-comparison/config.js
+++ b/population-pyramid-static-with-comparison/config.js
@@ -38,7 +38,7 @@ config = {
 			},
 			"centre": 60
 		},
-		"seriesHeight": {
+		"seriesHeight": {//only use integers
 			"sm": 6,
 			"md": 6,
 			"lg": 6

--- a/population-pyramid-static/config.js
+++ b/population-pyramid-static/config.js
@@ -36,7 +36,7 @@ config = {
 			},
 			"centre": 60
 		},
-		"seriesHeight": {
+		"seriesHeight": {//only use integers
 			"sm": 6,
 			"md": 6,
 			"lg": 6

--- a/population-pyramid-with-comparison-toggle/config.js
+++ b/population-pyramid-with-comparison-toggle/config.js
@@ -40,7 +40,7 @@ config = {
 			},
 			"centre": 60
 		},
-		"seriesHeight": {
+		"seriesHeight": {//only use integers
 			"sm": 6,
 			"md": 6,
 			"lg": 6

--- a/population-pyramid-with-dropdown-and-interactive-comparison/config.js
+++ b/population-pyramid-with-dropdown-and-interactive-comparison/config.js
@@ -39,7 +39,7 @@ config = {
 			},
 			"centre": 60
 		},
-		"seriesHeight": {
+		"seriesHeight": {//only use integers
 			"sm": 6,
 			"md": 6,
 			"lg": 6

--- a/population-pyramid-with-dropdown/config.js
+++ b/population-pyramid-with-dropdown/config.js
@@ -39,7 +39,7 @@ config = {
 			},
 			"centre": 60
 		},
-		"seriesHeight": {
+		"seriesHeight": {//only use integers
 			"sm": 6,
 			"md": 6,
 			"lg": 6


### PR DESCRIPTION
Adding comments in config to use only integers for setting pop pyramid height. Fixes #277