### PR TITLE
Adding option to config to make the chart be clustered

### DIFF
--- a/range-ci-area-grouped/config.js
+++ b/range-ci-area-grouped/config.js
@@ -4,6 +4,7 @@ config = {
 		"colour_palette": [
 			"#206095",
 			"#871A5B",
+			"#8D8C8E",
 			"#27A0CC",
 			"#A8BD3A",
 			"#F66068",
@@ -14,11 +15,14 @@ config = {
 			"A range plot with confidence intervals. This chart is hidden from screen readers. The main message is summarised by the chart title and the data behind the chart is available to download below.",
 		"xAxisTickFormat": ".0f",
 		"xAxisLabel": "x axis label",
-		"xDomain": [0, 160],
+		"xDomain": [0,160],
 		// either auto or a custom domain as an array e.g [0,100]
 		"CI_legend": true,
 		"CI_legend_interval_text": "Likely range (95% confidence interval)",
-		"CI_legend_text": "Estimated value"
+		"CI_legend_text": "Estimated value",
+		// If you have a third series, make sure to add it at the end of the script for the time being. This needs to be added as a reference option in config.
+		// If you want a clustered chart, true
+		"clustered": true, 
 	},
 	"optional": {
 		"margin": {

--- a/range-ci-area-grouped/data.csv
+++ b/range-ci-area-grouped/data.csv
@@ -25,3 +25,4 @@ South West,Group name 2,series 2,92.14356115,64.37920749,119.9079148
 South East,Group name 2,series 2,90.07397306,63.97314281,116.1748033
 Another name,Group name 3,series 2,100.190665,79.79415817,120.5871719
 And another,Group name 3,series 2,97,93,101
+All,Group name 1,all,53,20,86


### PR DESCRIPTION
If clustered = true, moves boxes and arrows to either side of the y tick. Also draws dashed y tick across chart as guide.