### PR TITLE
Fix action to copy lib folder

### DIFF
--- a/.github/workflows/sync_lib.yml
+++ b/.github/workflows/sync_lib.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ['main']
     paths: ['lib/**']
+  workflow_dispatch:
 
 jobs:
   sync-repos:
@@ -35,8 +36,7 @@ jobs:
     - name: Clear existing lib folders in target repo
       run: |
         # Clear lib folder
-        # rm -rf charts-lib/
-        # mkdir -p charts-lib/
+        find charts-lib -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} *
 
         rm -rf otherCharts/lib
         mkdir -p otherCharts/lib
@@ -44,25 +44,25 @@ jobs:
     - name: Copy files to target repo (excluding GitHub Actions)
       run: |
         # Copy
-        # rsync -av --exclude='.git' --exclude='.github' source-repo/ charts-lib/
-        rsync -av --exclude='.git' --exclude='.github' source-repo/ otherCharts/lib/
+        rsync -av --exclude='.git' --exclude='.github' source-repo/lib charts-lib/
+        rsync -av --exclude='.git' --exclude='.github' source-repo/lib otherCharts/lib/
     
-    # - name: Commit and push changes to charts-lib
-      # run: |
-        # cd charts-lib
-        # git config --local user.email "action@github.com"
-        # git config --local user.name "GitHub Action"
+    - name: Commit and push changes to charts-lib
+      run: |
+        cd charts-lib
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
         
-        # # Add all changes
-        # git add --all
+        # Add all changes
+        git add --all
         
-        # # Only commit if there are changes
-        # if git diff --staged --quiet; then
-        #   echo "No changes to commit to charts-lib"
-        # else
-        #   git commit -m "Sync from lib: ${{ github.sha }}"
-        #   git push
-        # fi
+        # Only commit if there are changes
+        if git diff --staged --quiet; then
+          echo "No changes to commit to charts-lib"
+        else
+          git commit -m "Sync from lib: ${{ github.sha }}"
+          git push
+        fi
 
     - name: Commit and push changes to otherCharts
       run: |


### PR DESCRIPTION
Closes #332 

Issue stemmed from using `rm -rf charts-lib` to tidy up before copying, since this also deleted the `.git` folder. Hoping this fixes it.