### PR TITLE
Improve scatter/bubble plot template

### DIFF
--- a/scatter-plot/config.js
+++ b/scatter-plot/config.js
@@ -1,8 +1,6 @@
 config={
   "graphic_data_url": "bubbleplotdata.csv",
   "colour_palette": [ONScolours.oceanBlue,ONScolours.springGreen,ONScolours.coralPink,ONScolours.skyBlue],
-  "fillOpacity":0.75,
-  "strokeOpacity":1,
   "sourceText": "Office for National Statistics",
   "accessibleSummary":"Here is the screenreader text describing the chart.",
   "xDomain":[0,1],
@@ -12,14 +10,14 @@ config={
   "xAxisFormat":".0%",
   "yAxisFormat":".0%",
   "groupLabel":'Group',
-  "sizeLabel":"Size", // Label for size for tooltips
-  "sizeLabelFormat":".0f",
   // Size scaling configuration
   "sizeConfig":{
       "enabled": true, // Set to false to disable size scaling
       "minSize": 25,   // Minimum circle size in pixels
       "maxSize": 500,  // Maximum circle size in pixels
-      "sizeField": 'size' // Field name in data that contains size values
+      "sizeField": 'size', // Field name in data that contains size values
+      "sizeLabel":"Size", // Label for size for tooltips and legend
+      "sizeLabelFormat":".0f",
   },
   "aspectRatio": {
     "sm": [1, 1],

--- a/scatter-plot/index.html
+++ b/scatter-plot/index.html
@@ -12,7 +12,6 @@
   <meta name="robots" content="noindex" />
   <meta name="googlebot" content="indexifembedded" />
 
-  <link rel="stylesheet" href="./dropdown.css" />
   <link rel="stylesheet" href="../lib/globalStyle.css" />
   <link rel="stylesheet" href="./chart.css"/>
   <link rel="stylesheet" href="https://cdn.ons.gov.uk/vendor/accessible-autocomplete/3.0.1/accessible-autocomplete.min.css"/>

--- a/scatter-plot/script.js
+++ b/scatter-plot/script.js
@@ -60,13 +60,14 @@ function drawGraphic() {
   if (sizeScale) {
     const sizeLegend = legend.append('div')
       .attr('class', 'size-legend')
-      .style('margin-top', '20px');
+      .style('margin-top', '20px')
+      .style('display', 'flex');
 
-    sizeLegend.append('h4')
-      .text('Size Scale')
-      .style('margin', '0 0 10px 0')
-      .style('font-size', '14px')
-      .style('font-weight', '600');
+    // sizeLegend.append('h4')
+    //   .text('Size Scale')
+    //   .style('margin', '0 0 10px 0')
+    //   .style('font-size', '14px')
+    //   .style('font-weight', '600');
 
     const sizeExtent = sizeScale.domain();
     const sizeLegendData = [sizeExtent[0], sizeExtent[1]];
@@ -81,20 +82,22 @@ function drawGraphic() {
       .style('margin-bottom', '5px');
 
     sizeLegendItems.append('svg')
-      .attr('width', 30)
-      .attr('height', d => Math.round(Math.sqrt(sizeScale(d) / Math.PI)*2))
+      .attr('width', d => Math.round(Math.sqrt(sizeScale(d) / Math.PI)*2)+2)
+      .attr('height', d => Math.round(Math.sqrt(sizeScale(d) / Math.PI)*2)+2)
       .append('circle')
-      .attr('cx', 15)
-      .attr('cy', d => Math.round(Math.sqrt(sizeScale(d) / Math.PI)))
-      .attr('r', d => Math.sqrt(sizeScale(d) / Math.PI))
+      .attr('cx', d => Math.round(Math.sqrt(sizeScale(d) / Math.PI))+0.5)
+      .attr('cy', d => Math.round(Math.sqrt(sizeScale(d) / Math.PI))+0.5)
+      .attr('r', d => Math.round(Math.sqrt(sizeScale(d) / Math.PI)))
       .attr('fill', config.colour_palette[0])
-      .attr('stroke', 'white')
+      .attr('fill-opacity', 0.75)
+      .attr('stroke', config.colour_palette[0])
       .attr('stroke-width', 1);
 
     sizeLegendItems.append('span')
       .style('margin-left', '5px')
+      .style('margin-right', '15px')
       .style('font-size', '12px')
-      .text(d => d3.format(config.sizeLabelFormat)(d));
+      .text(d => d3.format(config.sizeConfig.sizeLabelFormat)(d)+` ${config.sizeConfig.sizeLabel}`);
   }else{
     
 
@@ -242,11 +245,11 @@ function drawGraphic() {
     })
     .attr('transform', d => `translate(${x(d.xvalue)},${y(d.yvalue)})`)
     .attr('fill', d => colour(d.group))
-    .attr('fill-opacity', config.fillOpacity)
+    .attr('fill-opacity', config.sizeConfig.enabled ? 0.75 : 1)
     .attr('stroke', d => d.highlight === 'y' ? '#222' : config.sizeConfig.enabled ? ONScolours.oceanBlue : "#fff")
     .attr('stroke-width', d => d.highlight === 'y' ? '1.5px' : '1px')
     .attr('stroke-linejoin', 'round')
-    .attr('stroke-opacity', config.strokeOpacity);
+    .attr('stroke-opacity', 1);
 
   // Clean up previous overlay if it exists
   if (overlayCleanup) {
@@ -274,10 +277,10 @@ function drawGraphic() {
     tooltipConfig: {
       xValueFormat: d3.format(config.xAxisFormat),
       yValueFormat: d3.format(config.yAxisFormat),
-      sizeValueFormat: d3.format(config.sizeLabelFormat),
+      sizeValueFormat: d3.format(config.sizeConfig.sizeLabelFormat),
       xLabel: config.xAxisLabel || 'X Value',
       yLabel: config.yAxisLabel || 'Y Value',
-      sizeLabel: config.sizeLabel || 'Size',
+      sizeLabel: config.sizeConfig.sizeLabel || 'Size',
       groupLabel: config.groupLabel || 'Group',
       width: "250px",
       offset: { x: 3, y: 3 }


### PR DESCRIPTION
Remove unused fields in config as opacity and stroke-width are set in the from the Notion build specs and don't need to be set from the config.

Made the legend horizontal as per Notion styles