### PR TITLE
Clear out annotation on initialise

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -103,9 +103,10 @@ export function initialise(size, overrides = {}) {
   // population accessible summary (if needed, adjust as per your logic)
   d3.select("#accessibleSummary").html(config.accessibleSummary);
 
-  // clear out existing graphics
+  // clear out existing graphics and annotations (if used)
   d3.select("#graphic").selectAll("*").remove();
   d3.select("#legend").selectAll("*").remove();
+  d3.select(".mobile-annotation-footnotes-div").selectAll("*").remove();
 
   // set variables for chart dimensions dependent on width of #graphic
   const graphicWidth = parseInt(d3.select("#graphic").style("width"));


### PR DESCRIPTION
Annotation footnotes are now removed when initialised meaning no more duplication. This fixes z-annotation-bar-example among others.

<img width="402" height="767" alt="image" src="https://github.com/user-attachments/assets/549e1a82-f57b-467f-ab5e-c4b6518aa8a4" />
