### PR TITLE
fix: correct lavender spelling typo in colours helper

### DIFF
--- a/lib/colours.js
+++ b/lib/colours.js
@@ -24,7 +24,7 @@ const ONScolours = {
   springGreenDark: "#8a9b2e",
   beetrootPurple: "#871A5B",
   coralPink: "#f66068",
-  lavendarPurple: "#746cb1",
+  lavenderPurple: "#746cb1",
   mintGreen: "#22d0b6",
   mintGreenDark: "#1aa590",
   highlightOrange: "#f39431",

--- a/lib/globalStyle.css
+++ b/lib/globalStyle.css
@@ -20,7 +20,7 @@
   --ons-color-spring-green-dark: #8a9b2e;
   --ons-color-beetroot-purple: #871A5B;
   --ons-color-coral-pink: #F66068;
-  --ons-color-lavendar-purple: #746cb1;
+  --ons-color-lavender-purple: #746cb1;
   --ons-color-mint-green: #22d0b6;
   --ons-color-mint-green-dark: #1aa590;
   --ons-color-highlight-orange: #f39431;


### PR DESCRIPTION
Rename lavendarPurple → lavenderPurple in colours.js and --ons-color-lavendar-purple → --ons-color-lavender-purple in globalStyle.css. Fixes #452.