### PR TITLE
fix: arrowheads inherit stroke colour via context-stroke

### DIFF
--- a/lib/annotations.js
+++ b/lib/annotations.js
@@ -11,7 +11,10 @@ function setupArrowhead(svgContainer) {
     .attr("markerWidth", 20)
     .attr("markerHeight", 20)
     .attr("orient", "auto");
-  arrowheadMarker.append("path")
+  arrowheadMarker
+    .append("path")
+    .attr("stroke", "context-stroke")
+    .attr("fill", "none")
     .attr("d", "M2,5 L10,10 L2,15");
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -703,7 +703,11 @@ export function setupArrowhead(svgContainer) {
     .attr("markerWidth", 20)
     .attr("markerHeight", 20)
     .attr("orient", "auto");
-  arrowheadMarker.append("path").attr("d", "M2,5 L10,10 L2,15");
+  arrowheadMarker
+    .append("path")
+    .attr("stroke", "context-stroke")
+    .attr("fill", "none")
+    .attr("d", "M2,5 L10,10 L2,15");
 
   const arrowheadLeft = svgDefs
     .append("svg:marker")


### PR DESCRIPTION
Set stroke="context-stroke" and fill="none" on the annotation_arrowhead marker path in both helpers.js and annotations.js, matching the existing behaviour of annotation_arrowhead_left and annotation_arrowhead_right. Fixes #450.