### PR TITLE
fix: use categories index (not categoriesToPlot) for chart highlighting

### DIFF
--- a/line-chart-sm-focus/script.js
+++ b/line-chart-sm-focus/script.js
@@ -140,15 +140,15 @@ function drawGraphic() {
 				.datum(Object.entries(lines))
 				.attr('fill', 'none')
 				.attr(
-					'stroke', () => (categoriesToPlot.indexOf(category) == chartIndex) ? config.colourPalette[0] :
+					'stroke', () => (categories.indexOf(category) == chartIndex) ? config.colourPalette[0] :
 						category == reference ? config.colourPalette[1] : config.colourPalette[2]
 				)
-				.attr('stroke-width', () => (categoriesToPlot.indexOf(category) == chartIndex) || category == reference ? 2.5 : 2)
+				.attr('stroke-width', () => (categories.indexOf(category) == chartIndex) || category == reference ? 2.5 : 2)
 				.attr('d', (d, i) => lineGenerator(d[categoriesToPlot.indexOf(category)][1]))
 				.style('stroke-linejoin', 'round')
 				.style('stroke-linecap', 'round')
-				.attr('class', 'line' + categoriesToPlot.indexOf(category) +
-					((categoriesToPlot.indexOf(category) == chartIndex) ? " selected" :
+				.attr('class', 'line' + categories.indexOf(category) +
+					((categories.indexOf(category) == chartIndex) ? " selected" :
 						category == reference ? " reference" : " other"));
 
 			svg.selectAll('.reference').raise()
@@ -161,7 +161,7 @@ function drawGraphic() {
 				const lastValidDatum = [...graphicData].reverse().find(d => d[category] != null && d[category] !== "");
 				if (lastValidDatum) {
 					// Selected group - circle
-					if (categoriesToPlot.indexOf(category) == chartIndex) {
+					if (categories.indexOf(category) == chartIndex) {
 							drawShapeMarker({
 								svg,
 								shape: 'circle',


### PR DESCRIPTION
The highlighting logic compared categoriesToPlot.indexOf(category) against chartIndex, but chartIndex is derived from categories (which excludes the reference). When the reference column is not last in the CSV the indices are offset, causing the wrong line to be highlighted.

Switch all is-this-the-selected-series comparisons to use categories.indexOf(category), which correctly returns -1 for the reference so it never matches a chart index. The one remaining use of categoriesToPlot.indexOf(category) on the data accessor (line 147) is kept intentionally, as it indexes into Object.entries(lines) which is keyed by categoriesToPlot order. Fixes #443.