### PR TITLE
feat: rationalise drawLegend and addEndMarkers to three-value options

### DIFF
--- a/line-chart-dropdown-options/config.js
+++ b/line-chart-dropdown-options/config.js
@@ -1,7 +1,7 @@
 config = {
 	"graphicDataURL": "data.csv",
 	"colourPalette": ONSlinePalette,
-	"drawLegend": false,
+	"drawLegend": "auto", // true = always show, false = never show, "auto" = show only at sm size
 	"sourceText": "Office for National Statistics",
 	"accessibleSummary": "The chart canvas is hidden from screen readers. The main message is summarised by the chart title and the data behind the chart is available to download below.",
 	"lineCurveType": "curveLinear", // Set the default line curve type
@@ -81,7 +81,7 @@ config = {
 		"md": 5,
 		"lg": 8
 	},
-	"addEndMarkers": false,
+	"addEndMarkers": "auto", // true = always show, false = never show, "auto" = show only at sm size
 	"addPointMarkers": false,
 
 	"elements": { "select": 0, "nav": 0, "legend": 1, "titles": 0 }

--- a/line-chart-dropdown-options/script.js
+++ b/line-chart-dropdown-options/script.js
@@ -213,7 +213,7 @@ function drawGraphic() {
     svg.selectAll('g.line-end').remove();
     
 	// Add new end markers with varying shapes
-	if (config.addEndMarkers || size === 'sm') {
+	if (config.addEndMarkers === true || (config.addEndMarkers === 'auto' && size === 'sm')) {
 		circleData.forEach((d) => {
 			drawIndexedLineEndMarker({
 				svg,
@@ -242,7 +242,7 @@ function drawGraphic() {
         .remove();
 
 	// Handle legend vs direct labels
-	if (config.drawLegend || size === 'sm') {
+	if (config.drawLegend === true || (config.drawLegend === 'auto' && size === 'sm')) {
 		// Create legend (moved outside the loop)
 		let legenditem = d3
 			.select('#legend')

--- a/line-chart-sm-focus/config.js
+++ b/line-chart-sm-focus/config.js
@@ -94,6 +94,6 @@ config = {
 		secondaryTimeUnit: 'auto'//can be 'auto' or false to disable. set to "day","month",'quarter' or 'year' to override
 	},
 	"dropYAxis": true,
-	"addEndMarkers": true,
+	"addEndMarkers": true, // true = always show, false = never show, "auto" = show only at sm size
 	"elements": { "select": 0, "nav": 0, "legend": 1, "titles": 0 }
 };

--- a/line-chart-sm-focus/script.js
+++ b/line-chart-sm-focus/script.js
@@ -157,7 +157,7 @@ function drawGraphic() {
 			const lastDatum = graphicData[graphicData.length - 1];
 
 			// Add end markers for selected and comparison lines
-			if (config.addEndMarkers) {
+			if (config.addEndMarkers === true || (config.addEndMarkers === 'auto' && size === 'sm')) {
 				const lastValidDatum = [...graphicData].reverse().find(d => d[category] != null && d[category] !== "");
 				if (lastValidDatum) {
 					// Selected group - circle

--- a/line-chart-sm-multiseries/config.js
+++ b/line-chart-sm-multiseries/config.js
@@ -87,6 +87,6 @@ config = {
 	},
 	"dropYAxis": true,
 	"freeYAxisScales": false, //If true dropYAxis will be ignored - each chart will always have a y-axis
-	"addEndMarkers": true,
+	"addEndMarkers": true, // true = always show, false = never show, "auto" = show only at sm size
 	"elements": { "select": 0, "nav": 0, "legend": 1, "titles": 0 }
 };

--- a/line-chart-sm-multiseries/script.js
+++ b/line-chart-sm-multiseries/script.js
@@ -125,7 +125,7 @@ function drawGraphic() {
 		});
 
 		// Add end markers
-		if (config.addEndMarkers) {
+		if (config.addEndMarkers === true || (config.addEndMarkers === 'auto' && size === 'sm')) {
 			const markerData = categories.map((category, index) => {
 				// Find last valid datum for this category
 				const lastDatum = [...data].reverse().find(d => d[category] != null && d[category] !== "");

--- a/line-chart-with-ci-area-sm/config.js
+++ b/line-chart-with-ci-area-sm/config.js
@@ -100,6 +100,6 @@ config = {
 		secondaryTimeUnit: 'auto'//can be 'auto' or false to disable. set to "day","month",'quarter' or 'year' to override
 	},
 	"dropYAxis": true,
-	"addEndMarkers": true,
+	"addEndMarkers": true, // true = always show, false = never show, "auto" = show only at sm size
 	"elements": { "select": 0, "nav": 0, "legend": 1, "titles": 0 }
 };

--- a/line-chart-with-ci-area-sm/script.js
+++ b/line-chart-with-ci-area-sm/script.js
@@ -125,7 +125,7 @@ function drawGraphic() {
 				])
 				.attr('opacity', 0.3)
 
-			if (config.addEndMarkers) {
+			if (config.addEndMarkers === true || (config.addEndMarkers === 'auto' && size === 'sm')) {
 				// Add end marker for this category
 				const lastDatum = [...data].reverse().find(d => d[category] != null && d[category] !== "");
 				if (lastDatum) {

--- a/line-chart-with-ci-area/config.js
+++ b/line-chart-with-ci-area/config.js
@@ -5,7 +5,7 @@ config = {
 		ONScolours.beetrootPurple,
 		ONScolours.emeraldGreen
 	],
-	"drawLegend": false,
+	"drawLegend": "auto", // true = always show, false = never show, "auto" = show only at sm size
 	"sourceText": "Office for National Statistics",
 	"accessibleSummary": "The chart canvas is hidden from screen readers. The main message is summarised by the chart title and the data behind the chart is available to download below.",
 	"lineCurveType": "curveLinear", // Set the default line curve type
@@ -97,6 +97,6 @@ config = {
 	},
 	"addFirstDate": false,
 	"addFinalDate": false,
-	"addEndMarkers": true,
+	"addEndMarkers": true, // true = always show, false = never show, "auto" = show only at sm size
 	"elements": { "select": 0, "nav": 0, "legend": 1, "titles": 0 }
 };

--- a/line-chart-with-ci-area/script.js
+++ b/line-chart-with-ci-area/script.js
@@ -163,7 +163,7 @@ function drawGraphic() {
 			])
 			.attr('opacity', 0.3)
 
-		if (config.addEndMarkers || size === "sm") {
+		if (config.addEndMarkers === true || (config.addEndMarkers === 'auto' && size === 'sm')) {
 			// Add end marker for this category
 			const lastDatum = [...graphicData].reverse().find(d => d[category] != null && d[category] !== "");
 			if (lastDatum) {
@@ -182,7 +182,7 @@ function drawGraphic() {
 			}
 		}
 
-		if (config.drawLegend || size === 'sm') {
+		if (config.drawLegend === true || (config.drawLegend === 'auto' && size === 'sm')) {
 			// Set up the legend
 			let legenditem = d3
 				.select('#legend')
@@ -221,7 +221,7 @@ function drawGraphic() {
 		}
 	});
 
-	if (!config.drawLegend && size !== 'sm') {
+	if (!(config.drawLegend === true || (config.drawLegend === 'auto' && size === 'sm'))) {
 		createDirectLabels({
 			categories: categories,
 			data: graphicData,

--- a/line-chart/config.js
+++ b/line-chart/config.js
@@ -1,7 +1,7 @@
 config = {
 	"graphicDataURL": "data.csv",
 	"colourPalette": ONSlinePalette,
-	"drawLegend": true,
+	"drawLegend": true, // true = always show, false = never show, "auto" = show only at sm size
 	"sourceText": "Office for National Statistics",
 	"accessibleSummary": "The chart canvas is hidden from screen readers. The main message is summarised by the chart title and the data behind the chart is available to download below.",
 	"lineCurveType": "curveLinear", // Set the default line curve type
@@ -37,7 +37,7 @@ config = {
 	"yAxisLabel": "y axis label",
 	"xAxisLabel": "",
 	"zeroLine": "0",
-	"addEndMarkers":true,
+	"addEndMarkers":true, // true = always show, false = never show, "auto" = show only at sm size
 	"addPointMarkers": true, // Set to true to show markers on all available data points
 	"gapLineStyle": "dashed", // Style for lines over gaps: "dashed", "dotted", "solid" or "none"
 	"aspectRatio": {

--- a/line-chart/script.js
+++ b/line-chart/script.js
@@ -142,7 +142,7 @@ function drawGraphic() {
 			}
 
 			const lastDatum = graphicData[graphicData.length - 1];
-			if (lastDatum[category] === null || (config.drawLegend || size === 'sm')) return;
+			if (lastDatum[category] === null || (config.drawLegend === true || (config.drawLegend === 'auto' && size === 'sm'))) return;
 			const label = svg.append('text')
 				.attr('class', 'directLineLabel')
 				.attr('x', x(lastDatum.date) + 10)
@@ -164,7 +164,7 @@ function drawGraphic() {
 
 	});
 
-	if (config.addEndMarkers || size == "sm") {
+	if (config.addEndMarkers === true || (config.addEndMarkers === 'auto' && size === 'sm')) {
 		const markerData = categories.map((category, index) => {
 			// Find last valid datum for this category
 			const lastDatum = [...graphicData].reverse().find(d => d[category] != null && d[category] !== "");
@@ -192,7 +192,7 @@ function drawGraphic() {
 
 
 	// size === 'sm'
-	if (config.drawLegend || size === 'sm') {
+	if (config.drawLegend === true || (config.drawLegend === 'auto' && size === 'sm')) {
 		legend.selectAll("*").remove()
 
 		// Set up the legend


### PR DESCRIPTION
Both config options now support:
- true  = always active (regardless of chart size)
- false = never active (regardless of chart size)
- 'auto' = size-dependent, active only when size === 'sm' (previous implicit behaviour)

Previously, setting either option to false would still activate the feature at small (sm) size, which was confusing. The 'auto' value now makes this behaviour explicit and opt-in.

Configs updated to preserve existing visual behaviour:
- line-chart-dropdown-options: false → 'auto' for both options
- line-chart-with-ci-area: drawLegend false → 'auto'

Closes #408, closes #419